### PR TITLE
Update Multiselect.vue

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -518,6 +518,9 @@ fieldset[disabled] .multiselect {
 .multiselect__single {
   padding-left: 5px;
   margin-bottom: 8px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .multiselect__tags-wrap {


### PR DESCRIPTION
To avoid the textbox to expend on multiple lines when an option with long text is selected, I have changed the style of `.multiselect__single` to text-overflow: ellipsis and overflow of the element to hidden and white-space to nowrape.